### PR TITLE
fix(polyfills/intl): enable for IE11

### DIFF
--- a/packages/polyfill-library/polyfills/Intl/config.json
+++ b/packages/polyfill-library/polyfills/Intl/config.json
@@ -1,8 +1,8 @@
 {
 	"browsers": {
 		"android": "<=4.3",
-		"ie": "9 - 10",
-		"ie_mob": "10",
+		"ie": "9 - 11",
+		"ie_mob": "10 - 11",
 		"firefox": "<29",
 		"opera": "<15",
 		"chrome": "<=34",


### PR DESCRIPTION
IE11 actually does not fully support `Intl`.

For instance, [`DateTimeFormat#formatToParts`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatToParts#Syntax) is not available in IE11, but is in Chrome and Firefox. It is also included in the polyfill.

This PR therefore updates the polyfillable range for IE to `9 - 11` (from `9 - 10`) and for IE mobile to `10 - 11` (from just `10`).